### PR TITLE
[mod] 버전/상태정보 체크 목록에 ai-devops 모듈 추가

### DIFF
--- a/hypercloud-api-server/01_init.yaml
+++ b/hypercloud-api-server/01_init.yaml
@@ -330,3 +330,51 @@ data:
       readinessProbe:
 
       versionProbe:
+
+    - name: Notebook Controller
+      namespace: kubeflow
+      selector:
+        matchLabels:
+          statusLabel:
+          - app.kubernetes.io/component=notebook-controller
+          versionLabel:
+          - app.kubernetes.io/component=notebook-controller
+      readinessProbe:
+
+      versionProbe:
+
+    - name: Katib
+      namespace: kubeflow
+      selector:
+        matchLabels:
+          statusLabel:
+          - katib.kubeflow.org/component=controller
+          versionLabel:
+          - katib.kubeflow.org/component=controller
+      readinessProbe:
+
+      versionProbe:
+
+    - name: Kserve
+      namespace: kubeflow
+      selector:
+        matchLabels:
+          statusLabel:
+          - control-plane=kserve-controller-manager
+          versionLabel:
+          - control-plane=kserve-controller-manager
+      readinessProbe:
+
+      versionProbe:
+
+    - name: Training Operator
+      namespace: kubeflow
+      selector:
+        matchLabels:
+          statusLabel:
+          - control-plane=kubeflow-training-operator
+          versionLabel:
+          - control-plane=kubeflow-training-operator
+      readinessProbe:
+
+      versionProbe:


### PR DESCRIPTION
콘솔 메인화면에 상태/버전 상세목록에 ai-devops 모듈 추가

(공통)네임스페이스 : kubeflow

1. notebook-controller
app.kubernetes.io/component=notebook-controller
2. katib
katib.kubeflow.org/component=controller
3. kserve
control-plane=kserve-controller-manager
4. training-operator
control-plane=kubeflow-training-operator